### PR TITLE
Allow consumers to request all schedules from a feed

### DIFF
--- a/lib/mta.js
+++ b/lib/mta.js
@@ -83,9 +83,9 @@ Mta.prototype.status = function (service) {
 
 /**
  * Gets MTA schedule status
- * @param  {String|Array} stopId
- * @param  {String}       feedId    optional
- * @return {Object}       schedule
+ * @param  {Number|String|Array} stopId
+ * @param  {String}              feedId    optional
+ * @return {Object}              schedule
  */
 Mta.prototype.schedule = function (stopId, feedId) {
 
@@ -134,7 +134,6 @@ Mta.prototype.schedule = function (stopId, feedId) {
       if (_.isEmpty(t.trip_update)) {
         return;
       }
-
       t.trip_update.stop_time_update.map(function (s) {
         _.each(stopIds, function (stop) {
           if (s.stop_id.indexOf(stop) > -1) {

--- a/lib/mta.js
+++ b/lib/mta.js
@@ -82,6 +82,62 @@ Mta.prototype.status = function (service) {
 };
 
 /**
+ * Gets MTA schedules for all trains associated with a feedId
+ * @param  {String} feedId
+ * @return {Object} schedule
+ */
+Mta.prototype.schedulesForFeed = function (feedId) {
+  var schedule = {};
+  var results = false;
+  var direction, stopId, obj;
+  var options = _.pick(this.options, [ 'feed_id', 'key' ]);
+
+  if (!this.options.key) {
+    throw new Error('scheduleForFeed method requires MTA API key');
+  }
+
+  if (feedId) {
+    this.options.feed_id = feedId;
+  }
+
+  var feedUrl = this.urls.gtfs + qs.stringify(options);
+
+  // get binary feed
+  return fetch(feedUrl)
+  .then(parsers.gtfs)
+  .then(function(data) {
+    if (!data.entity || !Array.isArray(data.entity)) {
+      throw (err || new Error('malformed MTA response'));
+    }
+
+    data.entity.map(function (t) {
+      if (_.isEmpty(t.trip_update)) {
+        return;
+      }
+      t.trip_update.stop_time_update.map(function (s) {
+        stopId = s.stop_id.slice(0, -1);
+        direction = s.stop_id.slice(-1);
+        obj = utils.parseObj(t.trip_update.trip, s);
+        if (_.isNull(obj.arrival)) {
+          return;
+        }
+        if (schedule[stopId] === undefined) {
+          schedule[stopId] = { N: [], S: [] };
+        }
+        utils.binaryInsert('arrivalTime', obj, schedule[stopId][direction]);
+        results = true;
+      });
+    });
+
+    return results ? {
+        schedule: schedule,
+        updatedOn: data.header.timestamp.low
+      } : {};
+  });
+
+};
+
+/**
  * Gets MTA schedule status
  * @param  {Number|String|Array} stopId
  * @param  {String}              feedId    optional
@@ -105,7 +161,6 @@ Mta.prototype.schedule = function (stopId, feedId) {
     throw new Error('schedule method requires MTA API key');
   }
 
-  // TODO remove this requirement
   if (!stopId || typeof stopId === 'function') {
     throw new Error('stop id(s) are required');
   }

--- a/test/mta.js
+++ b/test/mta.js
@@ -24,7 +24,7 @@ describe('MTA', function () {
   it('should return info for all MTA subway stops', function () {
     return mta.stop()
     .then(function (result) {
-      result.should.be.an.Object;
+      result.should.be.an.Object();
     });
   });
 
@@ -67,7 +67,7 @@ describe('MTA', function () {
   it('should get MTA service status for 1 type', function () {
     return mta.status(serviceType)
     .then(function (result) {
-      result.should.be.an.Array;
+      result.should.be.an.Array();
     });
   });
 

--- a/test/mta.js
+++ b/test/mta.js
@@ -114,4 +114,18 @@ describe('MTA', function () {
     });
   });
 
+  it('should get schedule info for all stations with feed_id', function () {
+    return mta.schedulesForFeed(1)
+    .then(function (result) {
+      result.should.have.property('schedule');
+      result.should.have.property('updatedOn');
+      for (var stopId in result.schedule) {
+        var stopSchedule = result.schedule[stopId];
+        stopSchedule.should.be.an.Object();
+        stopSchedule.should.have.property('N');
+        stopSchedule.should.have.property('S');
+      }
+    });
+  });
+
 });


### PR DESCRIPTION
This new api method, `schedulesByFeed`, allows consumers to request all schedules for the specified feed id.

In contrast to the existing `schedules` method, this alternative does not require consumers to list
out stop id(s) for the stations that they are interested in.